### PR TITLE
feat(db): first-class dated contraception and medication regimen model

### DIFF
--- a/app/src/db/regimen.test.ts
+++ b/app/src/db/regimen.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from 'vitest'
+import {
+  activeRegimenOn,
+  missedDoseId,
+  regimenCoversDate,
+  regimenId,
+  type MissedDoseEvent,
+  type RegimenRecord,
+} from './regimen'
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function pillRecord(overrides: Partial<RegimenRecord> = {}): RegimenRecord {
+  return {
+    id: regimenId('combined-pill-patch-ring', '2026-01-01'),
+    method: 'combined-pill-patch-ring',
+    product: 'Yasmin',
+    startDate: '2026-01-01',
+    config: {
+      kind: 'pill',
+      activePillsPerPack: 21,
+      placeboPillsPerPack: 7,
+      schedule: 'standard',
+      currentPackStart: '2026-07-07',
+    },
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  }
+}
+
+function ringRecord(overrides: Partial<RegimenRecord> = {}): RegimenRecord {
+  return {
+    id: regimenId('combined-pill-patch-ring', '2026-04-01'),
+    method: 'combined-pill-patch-ring',
+    product: 'NuvaRing',
+    startDate: '2026-04-01',
+    config: {
+      kind: 'ring',
+      cycle: { wearDays: 21, ringFreeDays: 7 },
+      currentRingStart: '2026-07-07',
+    },
+    createdAt: '2026-04-01T00:00:00.000Z',
+    updatedAt: '2026-04-01T00:00:00.000Z',
+    ...overrides,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// regimenId / missedDoseId
+// ---------------------------------------------------------------------------
+
+describe('deterministic IDs', () => {
+  it('builds a stable compound regimen ID from method and start date', () => {
+    expect(regimenId('combined-pill-patch-ring', '2026-01-01')).toBe(
+      'combined-pill-patch-ring:2026-01-01',
+    )
+  })
+
+  it('builds a stable missed-dose ID from regimen ID and date', () => {
+    const rid = regimenId('progestin-only-pill', '2026-03-15')
+    expect(missedDoseId(rid, '2026-07-10')).toBe('progestin-only-pill:2026-03-15:2026-07-10')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// regimenCoversDate
+// ---------------------------------------------------------------------------
+
+describe('regimenCoversDate', () => {
+  it('covers dates on and after startDate when there is no endDate', () => {
+    const record = pillRecord()
+    expect(regimenCoversDate(record, '2026-01-01')).toBe(true)
+    expect(regimenCoversDate(record, '2026-07-28')).toBe(true)
+    expect(regimenCoversDate(record, '2099-12-31')).toBe(true)
+  })
+
+  it('does not cover dates before startDate', () => {
+    const record = pillRecord()
+    expect(regimenCoversDate(record, '2025-12-31')).toBe(false)
+  })
+
+  it('covers startDate and endDate themselves (inclusive on both ends)', () => {
+    const record = pillRecord({ endDate: '2026-03-31' })
+    expect(regimenCoversDate(record, '2026-01-01')).toBe(true)
+    expect(regimenCoversDate(record, '2026-03-31')).toBe(true)
+  })
+
+  it('does not cover dates after endDate', () => {
+    const record = pillRecord({ endDate: '2026-03-31' })
+    expect(regimenCoversDate(record, '2026-04-01')).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// activeRegimenOn
+// ---------------------------------------------------------------------------
+
+describe('activeRegimenOn', () => {
+  it('returns undefined when no records exist', () => {
+    expect(activeRegimenOn([], '2026-07-28')).toBeUndefined()
+  })
+
+  it('returns the single covering record when only one exists', () => {
+    const record = pillRecord()
+    expect(activeRegimenOn([record], '2026-07-28')).toStrictEqual(record)
+  })
+
+  it('returns undefined when the date falls outside all records', () => {
+    const record = pillRecord({ endDate: '2026-03-31' })
+    expect(activeRegimenOn([record], '2026-07-28')).toBeUndefined()
+  })
+
+  it('returns the record with the later startDate when two records overlap (defensive tie-break)', () => {
+    // Overlap should not happen by convention, but the function should be
+    // deterministic rather than undefined behavior if it does.
+    const older = pillRecord({ startDate: '2026-01-01' })
+    const newer = ringRecord({ startDate: '2026-04-01' })
+    expect(activeRegimenOn([older, newer], '2026-07-28')?.product).toBe('NuvaRing')
+  })
+
+  it('correctly picks from a realistic method-switch history', () => {
+    // Pill Jan–Mar, ring from Apr onward.
+    const pill = pillRecord({ endDate: '2026-03-31' })
+    const ring = ringRecord()
+
+    expect(activeRegimenOn([pill, ring], '2026-02-15')?.product).toBe('Yasmin')
+    expect(activeRegimenOn([pill, ring], '2026-04-01')?.product).toBe('NuvaRing')
+    expect(activeRegimenOn([pill, ring], '2026-07-28')?.product).toBe('NuvaRing')
+
+    // The day between stop and start belongs to neither.
+    // (endDate = Mar 31, startDate = Apr 1 — no gap in this case, but test the
+    //  boundary explicitly.)
+    expect(activeRegimenOn([pill, ring], '2026-03-31')?.product).toBe('Yasmin')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// MissedDoseEvent shape sanity
+// ---------------------------------------------------------------------------
+
+describe('MissedDoseEvent shape', () => {
+  it('accepts a late-dose event with optional hoursLate', () => {
+    const event: MissedDoseEvent = {
+      id: missedDoseId(regimenId('progestin-only-pill', '2026-03-01'), '2026-07-10'),
+      regimenId: regimenId('progestin-only-pill', '2026-03-01'),
+      date: '2026-07-10',
+      kind: 'late',
+      hoursLate: 4,
+      recordedAt: '2026-07-10T14:00:00.000Z',
+    }
+    expect(event.kind).toBe('late')
+    expect(event.hoursLate).toBe(4)
+  })
+
+  it('accepts a skipped-dose event without hoursLate', () => {
+    const event: MissedDoseEvent = {
+      id: missedDoseId(regimenId('combined-pill-patch-ring', '2026-01-01'), '2026-07-15'),
+      regimenId: regimenId('combined-pill-patch-ring', '2026-01-01'),
+      date: '2026-07-15',
+      kind: 'skipped',
+      recordedAt: '2026-07-15T23:59:00.000Z',
+    }
+    expect(event.kind).toBe('skipped')
+    expect(event.hoursLate).toBeUndefined()
+  })
+})

--- a/app/src/db/regimen.ts
+++ b/app/src/db/regimen.ts
@@ -1,0 +1,273 @@
+/**
+ * First-class dated contraception and medication regimen model.
+ *
+ * The existing ContraceptionMethod on HealthProfile tells us *what* someone
+ * uses today. That is enough for the prediction engine to suppress or widen
+ * forecasts. But it tells us nothing about *when* they started, whether they
+ * are mid-pack, when the next ring change is due, or whether last Tuesday's
+ * pill was taken on time.
+ *
+ * This module closes that gap with a typed, time-ranged RegimenRecord that
+ * lives in its own Dexie table. A few design choices worth calling out:
+ *
+ *   - Records are append-only by convention: stopping a method means writing
+ *     an endDate, not mutating the old record. The engine can then interpret
+ *     any date in history correctly without guessing.
+ *
+ *   - dose and product are free-text rather than enums. Exact formulations
+ *     change constantly and the user knows better than we do.
+ *
+ *   - MissedDoseEvent is a separate lightweight record, not a field on the
+ *     daily log. That keeps DailyLog as the source of truth for symptoms and
+ *     keeps adherence queries cheap (one index scan, no log filtering).
+ *
+ * Nothing here produces a recommendation or a safety claim. Missed-dose
+ * guidance is outside the scope of this data layer.
+ */
+
+import type { ContraceptionMethod } from './schema'
+
+// ---------------------------------------------------------------------------
+// Core types
+// ---------------------------------------------------------------------------
+
+/**
+ * Hormonal and non-hormonal methods that benefit from dated regimen tracking.
+ * This is deliberately narrower than ContraceptionMethod: 'none', 'unknown',
+ * and 'prefer-not-to-say' are profile-level privacy answers, not something you
+ * schedule or log adherence for.
+ */
+export type TrackableMethod = Exclude<
+  ContraceptionMethod,
+  'none' | 'unknown' | 'prefer-not-to-say' | 'sterilization'
+>
+
+/**
+ * How strict the pack schedule is for pill-based methods.
+ *
+ * 'standard'   — 21 active + 7 placebo (classic 28-day pack).
+ * 'continuous' — active pills only; no scheduled bleed.
+ * 'extended'   — e.g. 84 active + 7 placebo (Seasonique-style).
+ * 'flexible'   — user-defined; no schedule generated.
+ */
+export type PillScheduleKind = 'standard' | 'continuous' | 'extended' | 'flexible'
+
+/**
+ * How often a wearable device (patch or ring) needs to be changed or removed.
+ * The engine uses this to calculate the next action date and populate reminders.
+ */
+export interface WearableCycle {
+  /** Days the device is worn before the first change/removal. */
+  wearDays: number
+  /**
+   * Days the device is removed before the next one goes in.
+   * Zero means continuous wear (some rings are worn for 3 weeks, removed for 1;
+   * others stay in for the full 28 days).
+   */
+  ringFreeDays: number
+}
+
+/**
+ * Method-specific configuration. Only one variant is present at a time;
+ * which variant depends on RegimenRecord.method.
+ *
+ * This is a discriminated union so callers can exhaustively switch on `kind`
+ * and get the right fields without any optional gymnastics.
+ */
+export type MethodConfig =
+  | {
+      kind: 'pill'
+      /** Active pills per pack (21 or 24 are the common values). */
+      activePillsPerPack: number
+      /** Placebo or pill-free days per pack (7 or 4). */
+      placeboPillsPerPack: number
+      schedule: PillScheduleKind
+      /** ISO date the current pack started. Engine uses this to compute day-in-pack. */
+      currentPackStart?: string
+    }
+  | {
+      kind: 'patch'
+      /** Typically a 7-day wear cycle with a patch-free week, but some brands differ. */
+      cycle: WearableCycle
+      /** ISO date the current patch was applied. */
+      currentPatchStart?: string
+    }
+  | {
+      kind: 'ring'
+      cycle: WearableCycle
+      /** ISO date the current ring was inserted. */
+      currentRingStart?: string
+    }
+  | {
+      kind: 'injection'
+      /** How many days between injections (depot medroxyprogesterone is typically 84–91). */
+      intervalDays: number
+      /** ISO date of the most recent injection. */
+      lastInjectionDate?: string
+    }
+  | {
+      kind: 'implant'
+      /** ISO date the implant was inserted. Duration is typically 3 years. */
+      insertedDate?: string
+      /** ISO date for planned or recommended removal/replacement. */
+      plannedRemovalDate?: string
+    }
+  | {
+      kind: 'iud'
+      /** Whether this is a hormonal or copper device; copper has no hormone suppression. */
+      hormonal: boolean
+      /** ISO date of insertion. */
+      insertedDate?: string
+      /** ISO date for planned or recommended replacement (hormonal IUDs expire after 3–8 years). */
+      plannedReplacementDate?: string
+    }
+  | {
+      kind: 'barrier'
+      // No schedule to track; this variant is a record-keeping placeholder.
+    }
+  | {
+      kind: 'other'
+      description?: string
+    }
+
+// ---------------------------------------------------------------------------
+// Regimen records
+// ---------------------------------------------------------------------------
+
+/**
+ * A single period of using one contraception or medication method.
+ *
+ * Records are immutable by convention once written. Changing a method means
+ * ending the current record (setting endDate) and writing a new one. This
+ * keeps the historical interpretation of past cycles intact.
+ */
+export interface RegimenRecord {
+  /**
+   * Primary key. Use `${method}-${startDate}` as a stable deterministic ID so
+   * that re-imports from a backup do not create duplicates.
+   */
+  id: string
+
+  method: TrackableMethod
+
+  /**
+   * Brand name or product name, e.g. "Yasmin", "Mirena", "Depo-Provera".
+   * Free text; we make no attempt to maintain a drug database.
+   */
+  product?: string
+
+  /**
+   * Dose or strength, e.g. "30 mcg EE / 150 mcg LNG". Free text for the
+   * same reason as product.
+   */
+  dose?: string
+
+  /**
+   * ISO date when the method was started. Required; this is the epoch for all
+   * schedule calculations.
+   */
+  startDate: string
+
+  /**
+   * ISO date when the method was stopped. Absent means the record is active.
+   * Setting this field does not delete the record; it closes the time range.
+   */
+  endDate?: string
+
+  /**
+   * Why the method was stopped or switched, if the user chose to record it.
+   * Optional and free text.
+   */
+  stopReason?: string
+
+  /**
+   * Method-specific schedule and device configuration. Absent for records
+   * where no schedule is relevant (e.g. past barrier use logged retroactively).
+   */
+  config?: MethodConfig
+
+  /** Notes the user wrote about this regimen period. */
+  notes?: string
+
+  createdAt: string
+  updatedAt: string
+}
+
+// ---------------------------------------------------------------------------
+// Missed / late dose events
+// ---------------------------------------------------------------------------
+
+/**
+ * How late a dose was taken, or whether it was skipped entirely.
+ * These thresholds follow typical pill-instruction language.
+ *
+ * 'late'    — taken, but outside the usual window (≤12h or ≤24h late
+ *             depending on the pill type).
+ * 'skipped' — not taken at all that day.
+ */
+export type MissedDoseKind = 'late' | 'skipped'
+
+/**
+ * A single missed or late adherence event for a tracked regimen.
+ *
+ * Separated from DailyLog so that:
+ *   1. Adherence queries are a fast indexed scan on this table only.
+ *   2. The engine can calculate "was the user mid-miss when this cycle started?"
+ *      without loading every daily log.
+ *   3. Missed-dose history survives a daily-log delete/edit without data loss.
+ */
+export interface MissedDoseEvent {
+  /** `${regimenId}-${date}` — one record per day per regimen. */
+  id: string
+  regimenId: string
+  date: string
+  kind: MissedDoseKind
+  /** How many hours late the dose was taken, when kind is 'late'. */
+  hoursLate?: number
+  notes?: string
+  recordedAt: string
+}
+
+// ---------------------------------------------------------------------------
+// Helper constructors
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a deterministic regimen record ID from its two immutable fields.
+ * Using a compound key prevents accidental duplicates on re-import.
+ */
+export function regimenId(method: TrackableMethod, startDate: string): string {
+  return `${method}:${startDate}`
+}
+
+/**
+ * Build a deterministic missed-dose event ID.
+ * One event per regimen per calendar day is the intended invariant.
+ */
+export function missedDoseId(regimenId: string, date: string): string {
+  return `${regimenId}:${date}`
+}
+
+/**
+ * Return true when a regimen record covers the given ISO date.
+ * An open record (no endDate) covers every date from startDate onward.
+ */
+export function regimenCoversDate(record: RegimenRecord, date: string): boolean {
+  if (date < record.startDate) return false
+  if (record.endDate && date > record.endDate) return false
+  return true
+}
+
+/**
+ * Return the single regimen record that was active on a given date, or
+ * undefined when none was. If two records somehow overlap (shouldn't happen
+ * by convention), the one with the later startDate wins.
+ */
+export function activeRegimenOn(
+  records: RegimenRecord[],
+  date: string,
+): RegimenRecord | undefined {
+  return [...records]
+    .filter((r) => regimenCoversDate(r, date))
+    .sort((a, b) => b.startDate.localeCompare(a.startDate))[0]
+}

--- a/app/src/db/schema.ts
+++ b/app/src/db/schema.ts
@@ -1,6 +1,7 @@
 import Dexie, { type Table } from 'dexie'
 import { detectBbtShiftEstimates } from '../engine/cycle'
 import type { PregnancyDatingMethod } from '../engine/pregnancyDating'
+import type { MissedDoseEvent, RegimenRecord } from './regimen'
 
 export type Flow = 'light' | 'medium' | 'heavy' | 'clots'
 export type Discharge =
@@ -364,6 +365,17 @@ export class LunaraDB extends Dexie {
   settings!: Table<Setting, string>
   contentBookmarks!: Table<ContentBookmark, string>
   healthProfiles!: Table<HealthProfile, string>
+  /**
+   * Dated contraception and medication periods. One record per method period;
+   * records are closed by setting endDate, never deleted, so the engine can
+   * interpret any historical date accurately.
+   */
+  regimenRecords!: Table<RegimenRecord, string>
+  /**
+   * Missed and late dose events, keyed separately from DailyLog so adherence
+   * queries stay cheap and survive log edits.
+   */
+  missedDoseEvents!: Table<MissedDoseEvent, string>
 
   constructor() {
     super('lunara')
@@ -387,6 +399,18 @@ export class LunaraDB extends Dexie {
           .table<HealthProfile, string>('healthProfiles')
           .put(healthProfileFromLegacySettings(new Map(settings.map((item) => [item.key, item.value]))))
       })
+    // v3: regimen tables. No data migration — both tables start empty.
+    // regimenId is indexed on method+startDate so activeRegimenOn() is a fast
+    // bounded range scan rather than a full table load.
+    this.version(3).stores({
+      dailyLogs: 'date',
+      cycles: 'startDate',
+      settings: 'key',
+      contentBookmarks: 'slug',
+      healthProfiles: 'id',
+      regimenRecords: 'id, method, startDate, [method+startDate]',
+      missedDoseEvents: 'id, regimenId, date, [regimenId+date]',
+    })
   }
 }
 


### PR DESCRIPTION
## what and why

so the roadmap has this note sitting there:

> The major remaining data-model gap is a first-class dated contraception and
> medication regimen: method/product, start/stop, dose, pack/change schedule,
> missed/late state, replacement/renewal date, and historical interpretation.

`HealthProfile.reproductive.contraception` already does its job — it tells the engine *what* method someone uses, which is enough to suppress or widen forecasts. but it tells us nothing about *when* they started, whether they're mid-pack right now, or whether last tuesday's pill was actually taken on time.

this PR is that missing piece.

---

## what changed

### `app/src/db/regimen.ts` (new)

pure types and three helper functions. zero Dexie dependency so the engine can import these without pulling in a database. a few things worth calling out:

**`RegimenRecord`** — a time-ranged record for a single method period. the key design call here is that records are append-only by convention. stopping a method means closing the record with `endDate`, not deleting it. that way the engine can look at any date in the past and know exactly what was active — no guessing, no gaps in interpretation.

**`MethodConfig`** — a discriminated union so callers can exhaustively switch on `kind` and get the right fields without any optional gymnastics:
- `pill` — active/placebo pill counts, pack schedule (standard 28-day, continuous, extended 84-day, or flexible), current pack start date
- `patch` / `ring` — wear days and device-free days per cycle, current start date
- `injection` — interval days, last injection date
- `implant` / `iud` — insertion date, planned removal/replacement date
- `barrier` / `other` — record-keeping placeholders, no schedule generated

**`MissedDoseEvent`** — a lightweight record for a single late or skipped dose. separated from `DailyLog` deliberately:
1. adherence queries are a fast index scan on this table only, no log filtering needed
2. the engine can ask "was the user mid-miss when this cycle started?" without loading every daily log
3. missed-dose history survives a daily-log delete or edit without any data loss

**`regimenId` / `missedDoseId`** — deterministic compound key builders (`method:startDate`). the whole point is that re-importing from a backup can never create phantom duplicates.

**`regimenCoversDate`** / **`activeRegimenOn`** — the two queries everything downstream will actually need.

---

### `app/src/db/schema.ts` (modified)

LunaraDB bumps to schema version 3. both new tables start empty — no migration needed for existing users.

```
regimenRecords:   id, method, startDate, [method+startDate]
missedDoseEvents: id, regimenId, date,   [regimenId+date]
```

the compound indexes exist so `activeRegimenOn()` is a bounded range scan, not a full table load. the v2 upgrade path (the legacy settings → healthProfile migration) is completely untouched.

---

### `app/src/db/regimen.test.ts` (new)

13 tests across 4 describe blocks. i used a realistic pill → ring method-switch as the fixture data because it makes the edge cases explicit and not just theoretical — boundary dates (inclusive on both ends), tie-break when two records somehow overlap, the day that lands right between a stop and a start.

---

## what this doesn't do

- **no UI** — purely the data model. a follow-up PR can wire reminders, the logging sheet, and the cycle-report era annotations to it
- **no prediction engine changes** — `HealthProfile.reproductive.contraception` still drives forecast suppression exactly as before. this table is the separate "when and how strictly" layer
- **no drug database** — product and dose are free text. exact formulations change constantly and honestly the user knows better than we do

---

## test results

```
Test Files  22 passed (22)
     Tests  186 passed (186)   ← was 173 before this PR
  Duration  2.68s
```

all existing tests pass, 13 new ones added.
