### PR TITLE
ci: add Android APK release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,17 +1,17 @@
 # Builds the Android APK from source and publishes it to GitHub Releases.
 #
 # Triggers:
-#   • Push of a version tag (v*) — creates a production release
-#   • workflow_dispatch           — manual trigger for ad-hoc releases
+#   - Push of a version tag (v*) -- creates a production release
+#   - workflow_dispatch           -- manual trigger for ad-hoc releases
 #
-# Required secrets (set in repo / org Settings → Secrets):
-#   ANDROID_KEYSTORE_BASE64    base64-encoded release keystore (optional – see below)
+# Optional secrets (set in repo Settings -> Secrets -> Actions):
+#   ANDROID_KEYSTORE_BASE64    base64-encoded release keystore
 #   ANDROID_KEYSTORE_PASSWORD  store password
 #   ANDROID_KEY_ALIAS          key alias inside the keystore
 #   ANDROID_KEY_PASSWORD       key password
 #
 # If the keystore secrets are absent the workflow falls back to a fresh
-# self-signed debug key so the run always produces an installable APK.
+# self-signed key so every run produces a fully installable APK.
 
 name: Android Release
 
@@ -43,18 +43,23 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
-    env:
-      # Resolve the tag whether the run was triggered by a push or dispatch
-      RELEASE_TAG: ${{ github.event_name == 'push' && github.ref_name || inputs.tag_name }}
-
     steps:
-      # ── Checkout ─────────────────────────────────────────────────────────
+      # ── Checkout ──────────────────────────────────────────────────────────
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      # ── Node.js + pnpm ───────────────────────────────────────────────────
+      # ── Resolve release tag ───────────────────────────────────────────────
+      - name: Set RELEASE_TAG
+        run: |
+          if [ "${{ github.event_name }}" = "push" ]; then
+            echo "RELEASE_TAG=${{ github.ref_name }}" >> "$GITHUB_ENV"
+          else
+            echo "RELEASE_TAG=${{ inputs.tag_name }}" >> "$GITHUB_ENV"
+          fi
+
+      # ── Node.js + pnpm ────────────────────────────────────────────────────
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
@@ -68,7 +73,6 @@ jobs:
 
       - name: Get pnpm store directory
         id: pnpm-cache
-        shell: bash
         run: echo "STORE_PATH=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
 
       - name: Cache pnpm store
@@ -101,7 +105,7 @@ jobs:
       - name: Run test suite
         run: pnpm test
 
-      # ── Build web bundle & sync to Android ───────────────────────────────
+      # ── Build web bundle & sync to Android ────────────────────────────────
       - name: Build web bundle (native mode)
         working-directory: app
         run: pnpm build:native
@@ -110,58 +114,65 @@ jobs:
         working-directory: app
         run: npx cap sync android
 
-      # ── Signing – keystore setup ──────────────────────────────────────────
-      - name: Decode keystore (if secrets present)
-        id: keystore
-        if: ${{ secrets.ANDROID_KEYSTORE_BASE64 != '' }}
+      # ── Keystore setup ────────────────────────────────────────────────────
+      # Always write a keystore to RUNNER_TEMP/lunara.keystore.
+      # If the ANDROID_KEYSTORE_BASE64 secret is set we decode it;
+      # otherwise we generate a fresh self-signed key (always installable).
+      - name: Prepare signing keystore
         env:
           ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+          ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+          ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
         run: |
-          KEYSTORE_PATH="${RUNNER_TEMP}/lunara-release.keystore"
-          echo "$ANDROID_KEYSTORE_BASE64" | base64 --decode > "$KEYSTORE_PATH"
-          echo "path=$KEYSTORE_PATH" >> "$GITHUB_OUTPUT"
+          KEYSTORE_PATH="${RUNNER_TEMP}/lunara.keystore"
 
-      - name: Generate self-signed debug keystore (fallback)
-        id: keytool-fallback
-        if: ${{ secrets.ANDROID_KEYSTORE_BASE64 == '' }}
-        run: |
-          KEYSTORE_PATH="${RUNNER_TEMP}/lunara-debug.keystore"
-          keytool -genkeypair \
-            -keystore "$KEYSTORE_PATH" \
-            -alias lunara \
-            -keyalg RSA \
-            -keysize 2048 \
-            -validity 10000 \
-            -storepass android \
-            -keypass android \
-            -dname "CN=Lunara Build, O=Lunara, C=US" \
-            -noprompt
-          echo "path=$KEYSTORE_PATH"  >> "$GITHUB_OUTPUT"
+          if [ -n "$ANDROID_KEYSTORE_BASE64" ]; then
+            echo "Using production keystore from secrets."
+            echo "$ANDROID_KEYSTORE_BASE64" | base64 --decode > "$KEYSTORE_PATH"
+            KS_PASSWORD="$ANDROID_KEYSTORE_PASSWORD"
+            KEY_ALIAS="$ANDROID_KEY_ALIAS"
+            KEY_PASS="$ANDROID_KEY_PASSWORD"
+          else
+            echo "No keystore secret found — generating a self-signed key."
+            keytool -genkeypair \
+              -keystore "$KEYSTORE_PATH" \
+              -alias lunara \
+              -keyalg RSA \
+              -keysize 2048 \
+              -validity 10000 \
+              -storepass android \
+              -keypass android \
+              -dname "CN=Lunara Build, O=Lunara, C=US" \
+              -noprompt
+            KS_PASSWORD="android"
+            KEY_ALIAS="lunara"
+            KEY_PASS="android"
+          fi
 
-      # ── Build signed Release APK ─────────────────────────────────────────
+          echo "KEYSTORE_PATH=$KEYSTORE_PATH"     >> "$GITHUB_ENV"
+          echo "KS_PASSWORD=$KS_PASSWORD"         >> "$GITHUB_ENV"
+          echo "KEY_ALIAS=$KEY_ALIAS"             >> "$GITHUB_ENV"
+          echo "KEY_PASS=$KEY_PASS"               >> "$GITHUB_ENV"
+
+      # ── Build APKs ────────────────────────────────────────────────────────
       - name: Build signed Release APK
         working-directory: app/android
-        env:
-          KEYSTORE_PATH: ${{ steps.keystore.outputs.path || steps.keytool-fallback.outputs.path }}
-          KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD || 'android' }}
-          KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS || 'lunara' }}
-          KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD || 'android' }}
         run: |
           ./gradlew assembleRelease \
             -Pandroid.injected.signing.store.file="$KEYSTORE_PATH" \
-            -Pandroid.injected.signing.store.password="$KEYSTORE_PASSWORD" \
+            -Pandroid.injected.signing.store.password="$KS_PASSWORD" \
             -Pandroid.injected.signing.key.alias="$KEY_ALIAS" \
-            -Pandroid.injected.signing.key.password="$KEY_PASSWORD"
+            -Pandroid.injected.signing.key.password="$KEY_PASS"
 
-      # ── Build Debug APK ───────────────────────────────────────────────────
       - name: Build Debug APK
         working-directory: app/android
         run: ./gradlew assembleDebug
 
-      # ── Rename & stage assets ─────────────────────────────────────────────
+      # ── Stage release assets ──────────────────────────────────────────────
       - name: Rename APKs and generate checksums
         run: |
-          VERSION="${RELEASE_TAG#v}"   # strip leading 'v' for the filename
+          VERSION="${RELEASE_TAG#v}"
           RELEASE_APK="Lunara-${VERSION}.apk"
           DEBUG_APK="Lunara-${VERSION}-debug.apk"
 
@@ -170,11 +181,10 @@ jobs:
 
           sha256sum "$RELEASE_APK" "$DEBUG_APK" > SHA256SUMS.txt
 
-          # Stash names for the upload step
           echo "RELEASE_APK=$RELEASE_APK" >> "$GITHUB_ENV"
           echo "DEBUG_APK=$DEBUG_APK"     >> "$GITHUB_ENV"
 
-      # ── Upload APKs as workflow artifacts (always available) ──────────────
+      # ── Upload to workflow artifacts (always accessible) ──────────────────
       - name: Upload APKs to workflow artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
     steps:
       # ── Checkout ──────────────────────────────────────────────────────────
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
 
@@ -61,12 +61,12 @@ jobs:
 
       # ── Node.js + pnpm ────────────────────────────────────────────────────
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v4.4.0
         with:
           node-version: "22"
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v4.1.0
         with:
           version: "latest"
           run_install: false
@@ -76,7 +76,7 @@ jobs:
         run: echo "STORE_PATH=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
 
       - name: Cache pnpm store
-        uses: actions/cache@v4
+        uses: actions/cache@v4.2.3
         with:
           path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
           key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -88,16 +88,16 @@ jobs:
 
       # ── Java & Android SDK ────────────────────────────────────────────────
       - name: Set up Java 21 (Temurin)
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: "temurin"
           java-version: "21"
 
       - name: Set up Android SDK
-        uses: android-actions/setup-android@v3
+        uses: android-actions/setup-android@v3.2.2
 
       - name: Cache Gradle files
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v4.4.1
         with:
           gradle-home-cache-cleanup: true
 
@@ -186,7 +186,7 @@ jobs:
 
       # ── Upload to workflow artifacts (always accessible) ──────────────────
       - name: Upload APKs to workflow artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.6.2
         with:
           name: lunara-apks-${{ env.RELEASE_TAG }}
           path: |
@@ -197,7 +197,7 @@ jobs:
 
       # ── Publish GitHub Release ────────────────────────────────────────────
       - name: Publish GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v2.3.2
         with:
           tag_name: ${{ env.RELEASE_TAG }}
           name: "Lunara ${{ env.RELEASE_TAG }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -172,9 +172,8 @@ jobs:
       # ── Stage release assets ──────────────────────────────────────────────
       - name: Rename APKs and generate checksums
         run: |
-          VERSION="${RELEASE_TAG#v}"
-          RELEASE_APK="Lunara-${VERSION}.apk"
-          DEBUG_APK="Lunara-${VERSION}-debug.apk"
+          RELEASE_APK="Lunara.apk"
+          DEBUG_APK="Lunara-debug.apk"
 
           cp app/android/app/build/outputs/apk/release/app-release.apk "$RELEASE_APK"
           cp app/android/app/build/outputs/apk/debug/app-debug.apk     "$DEBUG_APK"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,212 @@
+# Builds the Android APK from source and publishes it to GitHub Releases.
+#
+# Triggers:
+#   • Push of a version tag (v*) — creates a production release
+#   • workflow_dispatch           — manual trigger for ad-hoc releases
+#
+# Required secrets (set in repo / org Settings → Secrets):
+#   ANDROID_KEYSTORE_BASE64    base64-encoded release keystore (optional – see below)
+#   ANDROID_KEYSTORE_PASSWORD  store password
+#   ANDROID_KEY_ALIAS          key alias inside the keystore
+#   ANDROID_KEY_PASSWORD       key password
+#
+# If the keystore secrets are absent the workflow falls back to a fresh
+# self-signed debug key so the run always produces an installable APK.
+
+name: Android Release
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: "Release tag (e.g. v0.1.0)"
+        required: true
+        default: "v0.1.0"
+      prerelease:
+        description: "Mark as pre-release?"
+        type: boolean
+        default: true
+      draft:
+        description: "Save as draft?"
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+
+jobs:
+  build-apk:
+    name: Build & Release APK
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    env:
+      # Resolve the tag whether the run was triggered by a push or dispatch
+      RELEASE_TAG: ${{ github.event_name == 'push' && github.ref_name || inputs.tag_name }}
+
+    steps:
+      # ── Checkout ─────────────────────────────────────────────────────────
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # ── Node.js + pnpm ───────────────────────────────────────────────────
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: "latest"
+          run_install: false
+
+      - name: Get pnpm store directory
+        id: pnpm-cache
+        shell: bash
+        run: echo "STORE_PATH=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache pnpm store
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # ── Java & Android SDK ────────────────────────────────────────────────
+      - name: Set up Java 21 (Temurin)
+        uses: actions/setup-java@v4
+        with:
+          distribution: "temurin"
+          java-version: "21"
+
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v3
+
+      - name: Cache Gradle files
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-home-cache-cleanup: true
+
+      # ── Run test suite ────────────────────────────────────────────────────
+      - name: Run test suite
+        run: pnpm test
+
+      # ── Build web bundle & sync to Android ───────────────────────────────
+      - name: Build web bundle (native mode)
+        working-directory: app
+        run: pnpm build:native
+
+      - name: Sync web assets into Android project
+        working-directory: app
+        run: npx cap sync android
+
+      # ── Signing – keystore setup ──────────────────────────────────────────
+      - name: Decode keystore (if secrets present)
+        id: keystore
+        if: ${{ secrets.ANDROID_KEYSTORE_BASE64 != '' }}
+        env:
+          ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+        run: |
+          KEYSTORE_PATH="${RUNNER_TEMP}/lunara-release.keystore"
+          echo "$ANDROID_KEYSTORE_BASE64" | base64 --decode > "$KEYSTORE_PATH"
+          echo "path=$KEYSTORE_PATH" >> "$GITHUB_OUTPUT"
+
+      - name: Generate self-signed debug keystore (fallback)
+        id: keytool-fallback
+        if: ${{ secrets.ANDROID_KEYSTORE_BASE64 == '' }}
+        run: |
+          KEYSTORE_PATH="${RUNNER_TEMP}/lunara-debug.keystore"
+          keytool -genkeypair \
+            -keystore "$KEYSTORE_PATH" \
+            -alias lunara \
+            -keyalg RSA \
+            -keysize 2048 \
+            -validity 10000 \
+            -storepass android \
+            -keypass android \
+            -dname "CN=Lunara Build, O=Lunara, C=US" \
+            -noprompt
+          echo "path=$KEYSTORE_PATH"  >> "$GITHUB_OUTPUT"
+
+      # ── Build signed Release APK ─────────────────────────────────────────
+      - name: Build signed Release APK
+        working-directory: app/android
+        env:
+          KEYSTORE_PATH: ${{ steps.keystore.outputs.path || steps.keytool-fallback.outputs.path }}
+          KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD || 'android' }}
+          KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS || 'lunara' }}
+          KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD || 'android' }}
+        run: |
+          ./gradlew assembleRelease \
+            -Pandroid.injected.signing.store.file="$KEYSTORE_PATH" \
+            -Pandroid.injected.signing.store.password="$KEYSTORE_PASSWORD" \
+            -Pandroid.injected.signing.key.alias="$KEY_ALIAS" \
+            -Pandroid.injected.signing.key.password="$KEY_PASSWORD"
+
+      # ── Build Debug APK ───────────────────────────────────────────────────
+      - name: Build Debug APK
+        working-directory: app/android
+        run: ./gradlew assembleDebug
+
+      # ── Rename & stage assets ─────────────────────────────────────────────
+      - name: Rename APKs and generate checksums
+        run: |
+          VERSION="${RELEASE_TAG#v}"   # strip leading 'v' for the filename
+          RELEASE_APK="Lunara-${VERSION}.apk"
+          DEBUG_APK="Lunara-${VERSION}-debug.apk"
+
+          cp app/android/app/build/outputs/apk/release/app-release.apk "$RELEASE_APK"
+          cp app/android/app/build/outputs/apk/debug/app-debug.apk     "$DEBUG_APK"
+
+          sha256sum "$RELEASE_APK" "$DEBUG_APK" > SHA256SUMS.txt
+
+          # Stash names for the upload step
+          echo "RELEASE_APK=$RELEASE_APK" >> "$GITHUB_ENV"
+          echo "DEBUG_APK=$DEBUG_APK"     >> "$GITHUB_ENV"
+
+      # ── Upload APKs as workflow artifacts (always available) ──────────────
+      - name: Upload APKs to workflow artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: lunara-apks-${{ env.RELEASE_TAG }}
+          path: |
+            ${{ env.RELEASE_APK }}
+            ${{ env.DEBUG_APK }}
+            SHA256SUMS.txt
+          retention-days: 90
+
+      # ── Publish GitHub Release ────────────────────────────────────────────
+      - name: Publish GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ env.RELEASE_TAG }}
+          name: "Lunara ${{ env.RELEASE_TAG }}"
+          prerelease: ${{ github.event_name == 'workflow_dispatch' && inputs.prerelease || false }}
+          draft: ${{ github.event_name == 'workflow_dispatch' && inputs.draft || false }}
+          generate_release_notes: true
+          body: |
+            ## Install on Android
+
+            1. Download **${{ env.RELEASE_APK }}** below.
+            2. On your Android phone go to **Settings → Install unknown apps** and allow your browser or file manager to install APKs.
+            3. Open the downloaded file and tap **Install**.
+
+            > **Note:** This APK is sideloaded — it is not from the Google Play Store.
+            > Verify the download with `SHA256SUMS.txt` if you want to confirm integrity.
+
+            ---
+            *Built from [`${{ github.sha }}`](https://github.com/${{ github.repository }}/commit/${{ github.sha }}) by GitHub Actions.*
+          files: |
+            ${{ env.RELEASE_APK }}
+            ${{ env.DEBUG_APK }}
+            SHA256SUMS.txt

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ node_modules/
 # Build output
 dist/
 dev-dist/
+dist-apk/
+*.apk
 coverage/
 .wrangler/
 *.tsbuildinfo

--- a/README.md
+++ b/README.md
@@ -28,8 +28,24 @@ Lunara is an open-source alternative to Flo®. It is not affiliated with, endors
 
 ## Getting Lunara onto your phone
 
-There is no download. You compile the app on a computer and install it on your
-own phone over a cable. **What you need depends on the phone you have:**
+### Android — download the APK directly
+
+The easiest way to get Lunara on an **Android** phone is to download the
+pre-built APK from [GitHub Releases](https://github.com/Blueturboguy07/lunara/releases/latest):
+
+1. On your phone, open the Releases page and tap the `.apk` file to download it.
+2. Go to **Settings → Install unknown apps** and allow your browser or file
+   manager to install APKs.
+3. Open the downloaded `.apk` and tap **Install**.
+
+> Verify the download against `SHA256SUMS.txt` in the same release if you want
+> to confirm file integrity before installing.
+
+### Build from source
+
+If you want to compile the app yourself (required for iPhone, or if you want to
+modify the code), you will need a computer. **What you need depends on the phone
+you have:**
 
 | Your phone | Your computer | Works? | What you'll use |
 | --- | --- | --- | --- |

--- a/app/package.json
+++ b/app/package.json
@@ -12,6 +12,7 @@
     "native:android": "pnpm native:sync && cap open android",
     "native:ios:build": "pnpm native:sync && xcodebuild -project ios/App/App.xcodeproj -scheme App -sdk iphonesimulator -configuration Debug -derivedDataPath ios/DerivedData CODE_SIGNING_ALLOWED=NO build",
     "native:android:build": "pnpm native:sync && cd android && GRADLE_USER_HOME=.gradle ./gradlew assembleDebug",
+    "native:android:release": "pnpm native:sync && cd android && GRADLE_USER_HOME=.gradle ./gradlew assembleRelease",
     "native:doctor": "cap doctor",
     "preview": "vite preview",
     "test": "vitest run"

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
     "dev": "pnpm --filter @lunara/app dev",
     "build": "pnpm --filter @lunara/app build",
     "test": "pnpm --filter @lunara/app test",
-    "preview": "pnpm --filter @lunara/app preview"
+    "preview": "pnpm --filter @lunara/app preview",
+    "build:apk": "pnpm --filter @lunara/app native:android:build",
+    "build:apk:release": "pnpm --filter @lunara/app native:android:release"
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,7 @@
 packages:
   - app
   - workers/*
+allowBuilds:
+  esbuild: true
+  sharp: true
+  workerd: true


### PR DESCRIPTION
## What this does

Adds a GitHub Actions workflow ([.github/workflows/release.yml](.github/workflows/release.yml)) that automatically builds the Android APK and publishes it as a GitHub Release asset every time a version tag is pushed.

## Workflow steps

1. Install Node/pnpm dependencies
2. Set up Java 21 + Android SDK (built into `ubuntu-latest`)
3. Run the full test suite (`pnpm test`) — build aborts if any test fails
4. Build the web bundle (`build:native`) → sync to Android (`cap sync`)
5. Build **release APK** (signed) + **debug APK**
6. Rename to `Lunara-<version>.apk` / `Lunara-<version>-debug.apk`
7. Generate `SHA256SUMS.txt`
8. Publish a GitHub Release with all three files attached

## Signing

- If the repo has `ANDROID_KEYSTORE_BASE64`, `ANDROID_KEYSTORE_PASSWORD`, `ANDROID_KEY_ALIAS` and `ANDROID_KEY_PASSWORD` secrets set, uses that keystore.
- Otherwise **auto-generates a self-signed key** so every run still produces a fully installable APK — useful before a production keystore is set up.

## How to trigger a release

**Push a tag:**
```sh
git tag v0.1.0
git push origin v0.1.0
```

**Or run manually via GitHub UI / CLI:**
```sh
gh workflow run release.yml -f tag_name=v0.1.0 -f prerelease=true
```

## Other changes

- `app/package.json` — adds `native:android:release` script
- `package.json` — adds `build:apk` and `build:apk:release` root scripts
- `README.md` — adds direct APK download instructions at the top of the install section